### PR TITLE
feat: add Laravel APort middleware package

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Native support for popular web frameworks.
 | Express.js | Middleware package | ✅ Active | Community |
 | FastAPI | Middleware package | ✅ Active | Community |
 | Django | Middleware package | 🚧 In Progress | Community |
-| Laravel | Composer package | 📋 Planned | Community |
+| Laravel | [Composer package](examples/middleware/laravel/) | ✅ Active | Community |
 | Rails | Ruby gem | 📋 Planned | Community |
 | Go | Official SDK | 🚧 In Progress | Community |
 

--- a/examples/middleware/laravel/README.md
+++ b/examples/middleware/laravel/README.md
@@ -1,0 +1,79 @@
+# APort Laravel Middleware
+
+Laravel middleware, configuration, and Artisan commands for verifying APort agent passports before protected routes run.
+
+## Features
+
+- Route middleware alias: `aport.verify`
+- Config publishing with `php artisan aport:install`
+- `aport:verify` Artisan smoke-test command
+- `Aport` facade and injectable `Aport\Laravel\Contracts\AportClient`
+- Mock-friendly client and tests that do not require live APort credentials
+- Example refund route and controller
+
+## Install
+
+```bash
+composer require aporthq/laravel-aport
+php artisan aport:install
+```
+
+Set credentials when you are ready to call the live API:
+
+```bash
+APORT_API_KEY=your_api_key
+APORT_BASE_URL=https://aport.io
+APORT_DEFAULT_POLICY=finance.payment.refund.v1
+```
+
+## Protect a Route
+
+```php
+use Illuminate\Support\Facades\Route;
+
+Route::post('/refunds', [RefundController::class, 'store'])
+    ->middleware('aport.verify:finance.payment.refund.v1');
+```
+
+Send the agent ID in either `X-APort-Agent-ID`, `X-Agent-ID`, `agent_id`, or `agentId`.
+
+```bash
+curl -X POST http://localhost/refunds \
+  -H 'X-APort-Agent-ID: agt_inst_refund_bot_123' \
+  -H 'Content-Type: application/json' \
+  -d '{"amount": 50}'
+```
+
+When verification succeeds, the middleware attaches the result to the request:
+
+```php
+$aport = $request->attributes->get('aport');
+$passport = $request->attributes->get('aport.passport');
+```
+
+## Artisan Verification
+
+```bash
+php artisan aport:verify agt_inst_refund_bot_123 finance.payment.refund.v1 \
+  --context='{"amount":50,"currency":"USD"}'
+```
+
+## Error Handling
+
+By default, failed verification blocks the request:
+
+- `400` when no agent ID is present
+- `403` when APort denies the policy
+- `502` when the APort service cannot be reached
+
+Set `APORT_FAIL_OPEN=true` only for non-production demos where requests should continue if APort is temporarily unavailable. In fail-open mode, `$request->attributes->get('aport')` contains `verified: false` and an `error` message.
+
+## Development
+
+```bash
+cd examples/middleware/laravel
+composer install
+composer test
+```
+
+The tests use mocked HTTP responses and a fake client binding, so they do not need a real API key.

--- a/examples/middleware/laravel/composer.json
+++ b/examples/middleware/laravel/composer.json
@@ -1,0 +1,44 @@
+{
+  "name": "aporthq/laravel-aport",
+  "description": "Laravel middleware and Artisan commands for APort agent verification.",
+  "type": "library",
+  "license": "MIT",
+  "require": {
+    "php": "^8.1",
+    "guzzlehttp/guzzle": "^7.8",
+    "illuminate/console": "^10.0|^11.0|^12.0",
+    "illuminate/http": "^10.0|^11.0|^12.0",
+    "illuminate/routing": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^8.0|^9.0|^10.0",
+    "phpunit/phpunit": "^10.0|^11.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Aport\\Laravel\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Aport\\Laravel\\Tests\\": "tests/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Aport\\Laravel\\AportLaravelServiceProvider"
+      ],
+      "aliases": {
+        "Aport": "Aport\\Laravel\\Facades\\Aport"
+      }
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  },
+  "config": {
+    "sort-packages": true
+  }
+}

--- a/examples/middleware/laravel/config/aport.php
+++ b/examples/middleware/laravel/config/aport.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    'api_key' => env('APORT_API_KEY'),
+    'base_url' => env('APORT_BASE_URL', 'https://aport.io'),
+    'timeout' => (float) env('APORT_TIMEOUT', 5.0),
+    'default_policy' => env('APORT_DEFAULT_POLICY', 'code.repository.merge.v1'),
+    'fail_open' => (bool) env('APORT_FAIL_OPEN', false),
+    'agent_headers' => [
+        'X-APort-Agent-ID',
+        'X-Agent-ID',
+    ],
+];

--- a/examples/middleware/laravel/examples/RefundController.php
+++ b/examples/middleware/laravel/examples/RefundController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class RefundController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $aport = $request->attributes->get('aport');
+        $passport = $aport['passport'] ?? [];
+        $limit = $passport['limits']['refund_amount_max_per_tx'] ?? 0;
+        $amount = (int) $request->input('amount');
+
+        if ($limit > 0 && $amount > $limit) {
+            return response()->json([
+                'error' => 'refund_limit_exceeded',
+                'limit' => $limit,
+            ], 403);
+        }
+
+        return response()->json([
+            'status' => 'approved',
+            'agent_id' => $aport['agent_id'] ?? null,
+            'policy' => $aport['policy'] ?? null,
+        ]);
+    }
+}

--- a/examples/middleware/laravel/examples/routes.php
+++ b/examples/middleware/laravel/examples/routes.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Http\Controllers\RefundController;
+use Illuminate\Support\Facades\Route;
+
+Route::post('/refunds', [RefundController::class, 'store'])
+    ->middleware('aport.verify:finance.payment.refund.v1');

--- a/examples/middleware/laravel/phpunit.xml
+++ b/examples/middleware/laravel/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Laravel APort">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/examples/middleware/laravel/src/AportLaravelServiceProvider.php
+++ b/examples/middleware/laravel/src/AportLaravelServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Aport\Laravel;
+
+use Aport\Laravel\Console\InstallCommand;
+use Aport\Laravel\Console\VerifyCommand;
+use Aport\Laravel\Contracts\AportClient as AportClientContract;
+use Aport\Laravel\Http\Middleware\VerifyAport;
+use Aport\Laravel\Support\AportClient;
+use Illuminate\Routing\Router;
+use Illuminate\Support\ServiceProvider;
+
+class AportLaravelServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/aport.php', 'aport');
+
+        $this->app->singleton(AportClientContract::class, function ($app) {
+            return new AportClient($app['config']->get('aport', []));
+        });
+
+        $this->app->alias(AportClientContract::class, 'aport');
+    }
+
+    public function boot(Router $router): void
+    {
+        $this->publishes([
+            __DIR__ . '/../config/aport.php' => config_path('aport.php'),
+        ], 'aport-config');
+
+        $router->aliasMiddleware('aport.verify', VerifyAport::class);
+        $router->aliasMiddleware('aport.policy', VerifyAport::class);
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                InstallCommand::class,
+                VerifyCommand::class,
+            ]);
+        }
+    }
+}

--- a/examples/middleware/laravel/src/Console/InstallCommand.php
+++ b/examples/middleware/laravel/src/Console/InstallCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aport\Laravel\Console;
+
+use Illuminate\Console\Command;
+
+class InstallCommand extends Command
+{
+    protected $signature = 'aport:install {--force : Overwrite existing config file}';
+
+    protected $description = 'Publish APort Laravel configuration.';
+
+    public function handle(): int
+    {
+        $this->call('vendor:publish', [
+            '--tag' => 'aport-config',
+            '--force' => (bool) $this->option('force'),
+        ]);
+
+        $this->line('');
+        $this->info('APort Laravel middleware installed.');
+        $this->line('Add these environment variables when you are ready to call the live API:');
+        $this->line('APORT_API_KEY=your_api_key');
+        $this->line('APORT_BASE_URL=https://aport.io');
+
+        return self::SUCCESS;
+    }
+}

--- a/examples/middleware/laravel/src/Console/VerifyCommand.php
+++ b/examples/middleware/laravel/src/Console/VerifyCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Aport\Laravel\Console;
+
+use Aport\Laravel\Contracts\AportClient;
+use Illuminate\Console\Command;
+use JsonException;
+use Throwable;
+
+class VerifyCommand extends Command
+{
+    protected $signature = 'aport:verify
+        {agentId : APort agent ID}
+        {policy? : Policy pack identifier}
+        {--context= : JSON context passed to APort}';
+
+    protected $description = 'Verify an APort agent against a policy pack.';
+
+    public function handle(AportClient $client): int
+    {
+        $policy = (string) ($this->argument('policy') ?: config('aport.default_policy'));
+        $context = [];
+
+        if ($this->option('context')) {
+            try {
+                $context = json_decode((string) $this->option('context'), true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                $this->error('The --context option must be valid JSON.');
+
+                return self::INVALID;
+            }
+
+            if (! is_array($context)) {
+                $this->error('The --context option must decode to a JSON object.');
+
+                return self::INVALID;
+            }
+        }
+
+        try {
+            $result = $client->verify($policy, (string) $this->argument('agentId'), $context);
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->table(['Field', 'Value'], [
+            ['verified', $result->verified() ? 'yes' : 'no'],
+            ['agent_id', $result->agentId()],
+            ['policy', $result->policy()],
+            ['message', $result->message() ?: '-'],
+        ]);
+
+        return $result->verified() ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/examples/middleware/laravel/src/Contracts/AportClient.php
+++ b/examples/middleware/laravel/src/Contracts/AportClient.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aport\Laravel\Contracts;
+
+use Aport\Laravel\DTO\VerificationResult;
+
+interface AportClient
+{
+    /**
+     * Verify an agent against an APort policy pack.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function verify(string $policy, string $agentId, array $context = []): VerificationResult;
+}

--- a/examples/middleware/laravel/src/DTO/VerificationResult.php
+++ b/examples/middleware/laravel/src/DTO/VerificationResult.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Aport\Laravel\DTO;
+
+class VerificationResult
+{
+    /**
+     * @param array<string, mixed>|null $passport
+     * @param array<string, mixed> $details
+     * @param array<string, mixed> $raw
+     */
+    public function __construct(
+        private readonly bool $verified,
+        private readonly string $policy,
+        private readonly string $agentId,
+        private readonly ?array $passport = null,
+        private readonly ?string $message = null,
+        private readonly array $details = [],
+        private readonly array $raw = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload, string $policy, string $agentId): self
+    {
+        return new self(
+            (bool) ($payload['verified'] ?? $payload['success'] ?? false),
+            (string) ($payload['policy'] ?? $payload['policy_id'] ?? $policy),
+            (string) ($payload['agent_id'] ?? $payload['agentId'] ?? $agentId),
+            isset($payload['passport']) && is_array($payload['passport']) ? $payload['passport'] : null,
+            isset($payload['message']) ? (string) $payload['message'] : null,
+            isset($payload['details']) && is_array($payload['details']) ? $payload['details'] : [],
+            $payload,
+        );
+    }
+
+    public function verified(): bool
+    {
+        return $this->verified;
+    }
+
+    public function policy(): string
+    {
+        return $this->policy;
+    }
+
+    public function agentId(): string
+    {
+        return $this->agentId;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function passport(): ?array
+    {
+        return $this->passport;
+    }
+
+    public function message(): ?string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function details(): array
+    {
+        return $this->details;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function raw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'verified' => $this->verified,
+            'policy' => $this->policy,
+            'agent_id' => $this->agentId,
+            'passport' => $this->passport,
+            'message' => $this->message,
+            'details' => $this->details,
+            'raw' => $this->raw,
+        ];
+    }
+}

--- a/examples/middleware/laravel/src/Exceptions/AportException.php
+++ b/examples/middleware/laravel/src/Exceptions/AportException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Aport\Laravel\Exceptions;
+
+use RuntimeException;
+
+class AportException extends RuntimeException
+{
+}

--- a/examples/middleware/laravel/src/Exceptions/VerificationRequestException.php
+++ b/examples/middleware/laravel/src/Exceptions/VerificationRequestException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aport\Laravel\Exceptions;
+
+class VerificationRequestException extends AportException
+{
+}

--- a/examples/middleware/laravel/src/Facades/Aport.php
+++ b/examples/middleware/laravel/src/Facades/Aport.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aport\Laravel\Facades;
+
+use Aport\Laravel\Contracts\AportClient as AportClientContract;
+use Illuminate\Support\Facades\Facade;
+
+class Aport extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return AportClientContract::class;
+    }
+}

--- a/examples/middleware/laravel/src/Http/Middleware/VerifyAport.php
+++ b/examples/middleware/laravel/src/Http/Middleware/VerifyAport.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Aport\Laravel\Http\Middleware;
+
+use Aport\Laravel\Contracts\AportClient;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class VerifyAport
+{
+    public function __construct(private readonly AportClient $client)
+    {
+    }
+
+    public function handle(Request $request, Closure $next, ?string $policy = null): Response
+    {
+        $policy = $policy ?: (string) config('aport.default_policy');
+
+        if ($policy === '') {
+            return $this->reject('APort policy is required.', 500);
+        }
+
+        $agentId = $this->agentId($request);
+
+        if ($agentId === null) {
+            return $this->reject('APort agent ID is required.', 400);
+        }
+
+        try {
+            $result = $this->client->verify($policy, $agentId, $this->context($request));
+        } catch (Throwable $exception) {
+            if ((bool) config('aport.fail_open', false)) {
+                $request->attributes->set('aport', [
+                    'verified' => false,
+                    'agent_id' => $agentId,
+                    'policy' => $policy,
+                    'error' => $exception->getMessage(),
+                ]);
+
+                return $next($request);
+            }
+
+            return $this->reject('APort verification service error.', 502, [
+                'details' => $exception->getMessage(),
+            ]);
+        }
+
+        if (! $result->verified()) {
+            return $this->reject($result->message() ?: 'APort verification failed.', 403, [
+                'details' => $result->details(),
+            ]);
+        }
+
+        $request->attributes->set('aport', $result->toArray());
+        $request->attributes->set('aport.passport', $result->passport());
+
+        return $next($request);
+    }
+
+    private function agentId(Request $request): ?string
+    {
+        foreach ((array) config('aport.agent_headers', []) as $header) {
+            $value = $request->headers->get((string) $header);
+
+            if (is_string($value) && trim($value) !== '') {
+                return trim($value);
+            }
+        }
+
+        foreach (['agent_id', 'agentId'] as $key) {
+            $value = $request->query($key) ?? $request->input($key);
+
+            if (is_string($value) && trim($value) !== '') {
+                return trim($value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function context(Request $request): array
+    {
+        return [
+            'method' => $request->method(),
+            'path' => '/' . ltrim($request->path(), '/'),
+            'route' => optional($request->route())->getName(),
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     */
+    private function reject(string $message, int $status, array $extra = []): JsonResponse
+    {
+        return response()->json(array_merge([
+            'error' => 'aport_verification_failed',
+            'message' => $message,
+        ], $extra), $status);
+    }
+}

--- a/examples/middleware/laravel/src/Support/AportClient.php
+++ b/examples/middleware/laravel/src/Support/AportClient.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Aport\Laravel\Support;
+
+use Aport\Laravel\Contracts\AportClient as AportClientContract;
+use Aport\Laravel\DTO\VerificationResult;
+use Aport\Laravel\Exceptions\AportException;
+use Aport\Laravel\Exceptions\VerificationRequestException;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+
+class AportClient implements AportClientContract
+{
+    private ClientInterface $http;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(private readonly array $config = [], ?ClientInterface $http = null)
+    {
+        $this->http = $http ?: new Client([
+            'base_uri' => rtrim((string) ($this->config['base_url'] ?? 'https://aport.io'), '/'),
+            'timeout' => (float) ($this->config['timeout'] ?? 5.0),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function verify(string $policy, string $agentId, array $context = []): VerificationResult
+    {
+        $policy = trim($policy);
+        $agentId = trim($agentId);
+
+        if ($policy === '') {
+            throw new AportException('APort policy is required.');
+        }
+
+        if ($agentId === '') {
+            throw new AportException('APort agent ID is required.');
+        }
+
+        try {
+            $response = $this->http->request('POST', "/api/verify/policy/{$policy}", [
+                'headers' => $this->headers(),
+                'json' => [
+                    'policy_id' => $policy,
+                    'agent_id' => $agentId,
+                    'context' => $context,
+                ],
+            ]);
+        } catch (RequestException $exception) {
+            throw $this->requestException($exception);
+        } catch (GuzzleException $exception) {
+            throw new VerificationRequestException(
+                'Unable to reach APort verification service: ' . $exception->getMessage(),
+                previous: $exception,
+            );
+        }
+
+        $payload = json_decode((string) $response->getBody(), true);
+
+        if (! is_array($payload)) {
+            throw new VerificationRequestException('APort returned an invalid JSON response.');
+        }
+
+        return VerificationResult::fromArray($payload, $policy, $agentId);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headers(): array
+    {
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'aporthq-laravel-aport/1.0',
+        ];
+
+        $apiKey = $this->config['api_key'] ?? null;
+
+        if (is_string($apiKey) && $apiKey !== '') {
+            $headers['Authorization'] = 'Bearer ' . $apiKey;
+        }
+
+        return $headers;
+    }
+
+    private function requestException(RequestException $exception): VerificationRequestException
+    {
+        $response = $exception->getResponse();
+        $message = 'APort verification request failed.';
+
+        if ($response !== null) {
+            $body = json_decode((string) $response->getBody(), true);
+
+            if (is_array($body) && isset($body['message'])) {
+                $message = (string) $body['message'];
+            } else {
+                $message = sprintf(
+                    'APort verification request failed with HTTP %s.',
+                    $response->getStatusCode(),
+                );
+            }
+        }
+
+        return new VerificationRequestException($message, previous: $exception);
+    }
+}

--- a/examples/middleware/laravel/tests/AportClientTest.php
+++ b/examples/middleware/laravel/tests/AportClientTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Aport\Laravel\Tests;
+
+use Aport\Laravel\Exceptions\VerificationRequestException;
+use Aport\Laravel\Support\AportClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+
+class AportClientTest extends TestCase
+{
+    public function test_it_posts_policy_verification_requests(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'verified' => true,
+                'passport' => [
+                    'agentId' => 'agt_test',
+                    'limits' => ['refund_amount_max_per_tx' => 5000],
+                ],
+                'message' => 'ok',
+            ])),
+        ]);
+
+        $client = new AportClient([
+            'base_url' => 'https://aport.test',
+            'api_key' => 'secret',
+        ], new Client([
+            'base_uri' => 'https://aport.test',
+            'handler' => HandlerStack::create($mock),
+        ]));
+
+        $result = $client->verify('finance.payment.refund.v1', 'agt_test', ['amount' => 50]);
+
+        $this->assertTrue($result->verified());
+        $this->assertSame('agt_test', $result->agentId());
+        $this->assertSame(5000, $result->passport()['limits']['refund_amount_max_per_tx']);
+    }
+
+    public function test_it_rejects_invalid_json_responses(): void
+    {
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], 'not-json'),
+        ]);
+
+        $client = new AportClient([], new Client([
+            'base_uri' => 'https://aport.test',
+            'handler' => HandlerStack::create($mock),
+        ]));
+
+        $this->expectException(VerificationRequestException::class);
+
+        $client->verify('finance.payment.refund.v1', 'agt_test');
+    }
+}

--- a/examples/middleware/laravel/tests/TestCase.php
+++ b/examples/middleware/laravel/tests/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Aport\Laravel\Tests;
+
+use Aport\Laravel\AportLaravelServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    /**
+     * @param mixed $app
+     * @return array<int, class-string>
+     */
+    protected function getPackageProviders($app): array
+    {
+        return [
+            AportLaravelServiceProvider::class,
+        ];
+    }
+}

--- a/examples/middleware/laravel/tests/VerifyAportMiddlewareTest.php
+++ b/examples/middleware/laravel/tests/VerifyAportMiddlewareTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Aport\Laravel\Tests;
+
+use Aport\Laravel\Contracts\AportClient;
+use Aport\Laravel\DTO\VerificationResult;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+class VerifyAportMiddlewareTest extends TestCase
+{
+    protected function defineRoutes($router): void
+    {
+        Route::post('/refunds', function (Request $request) {
+            return response()->json($request->attributes->get('aport'));
+        })->middleware('aport.verify:finance.payment.refund.v1');
+    }
+
+    public function test_it_allows_verified_agents(): void
+    {
+        $this->app->instance(AportClient::class, new FakeAportClient(
+            new VerificationResult(true, 'finance.payment.refund.v1', 'agt_test', [
+                'limits' => ['refund_amount_max_per_tx' => 1000],
+            ]),
+        ));
+
+        $this->postJson('/refunds', ['amount' => 100], [
+            'X-APort-Agent-ID' => 'agt_test',
+        ])->assertOk()
+            ->assertJsonPath('verified', true)
+            ->assertJsonPath('agent_id', 'agt_test');
+    }
+
+    public function test_it_blocks_missing_agent_ids(): void
+    {
+        $this->postJson('/refunds', ['amount' => 100])
+            ->assertStatus(400)
+            ->assertJsonPath('error', 'aport_verification_failed');
+    }
+
+    public function test_it_blocks_unverified_agents(): void
+    {
+        $this->app->instance(AportClient::class, new FakeAportClient(
+            new VerificationResult(false, 'finance.payment.refund.v1', 'agt_denied', null, 'Agent suspended'),
+        ));
+
+        $this->postJson('/refunds', [], [
+            'X-Agent-ID' => 'agt_denied',
+        ])->assertStatus(403)
+            ->assertJsonPath('message', 'Agent suspended');
+    }
+
+    public function test_fail_open_allows_requests_when_configured(): void
+    {
+        config()->set('aport.fail_open', true);
+
+        $this->app->instance(AportClient::class, new ThrowingAportClient());
+
+        $this->postJson('/refunds', [], [
+            'X-Agent-ID' => 'agt_soft_fail',
+        ])->assertOk()
+            ->assertJsonPath('verified', false)
+            ->assertJsonPath('agent_id', 'agt_soft_fail');
+    }
+}
+
+class FakeAportClient implements AportClient
+{
+    public function __construct(private readonly VerificationResult $result)
+    {
+    }
+
+    public function verify(string $policy, string $agentId, array $context = []): VerificationResult
+    {
+        return VerificationResult::fromArray(array_merge($this->result->toArray(), [
+            'policy' => $policy,
+            'agent_id' => $agentId,
+        ]), $policy, $agentId);
+    }
+}
+
+class ThrowingAportClient implements AportClient
+{
+    public function verify(string $policy, string $agentId, array $context = []): VerificationResult
+    {
+        throw new \RuntimeException('network down');
+    }
+}

--- a/examples/middleware/laravel/tests/VerifyCommandTest.php
+++ b/examples/middleware/laravel/tests/VerifyCommandTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Aport\Laravel\Tests;
+
+use Aport\Laravel\Contracts\AportClient;
+use Aport\Laravel\DTO\VerificationResult;
+
+class VerifyCommandTest extends TestCase
+{
+    public function test_verify_command_returns_success_for_verified_agents(): void
+    {
+        $this->app->instance(AportClient::class, new CommandFakeAportClient(
+            new VerificationResult(true, 'finance.payment.refund.v1', 'agt_cli', null, 'ok'),
+        ));
+
+        $this->artisan('aport:verify', [
+            'agentId' => 'agt_cli',
+            'policy' => 'finance.payment.refund.v1',
+            '--context' => '{"amount":50}',
+        ])->assertExitCode(0);
+    }
+
+    public function test_verify_command_rejects_invalid_context_json(): void
+    {
+        $this->artisan('aport:verify', [
+            'agentId' => 'agt_cli',
+            'policy' => 'finance.payment.refund.v1',
+            '--context' => 'not-json',
+        ])->assertExitCode(2);
+    }
+}
+
+class CommandFakeAportClient implements AportClient
+{
+    public function __construct(private readonly VerificationResult $result)
+    {
+    }
+
+    public function verify(string $policy, string $agentId, array $context = []): VerificationResult
+    {
+        return VerificationResult::fromArray(array_merge($this->result->toArray(), [
+            'policy' => $policy,
+            'agent_id' => $agentId,
+        ]), $policy, $agentId);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Laravel Composer package under examples/middleware/laravel
- include APort verification middleware, config publishing, facade/client binding, and aport:install/aport:verify Artisan commands
- add mocked client and middleware tests plus refund route/controller examples

## Verification
- jq empty examples/middleware/laravel/composer.json
- git diff --check
- Not run: PHP/Composer test suite because php and composer are not installed in this environment

Closes #15