### PR TITLE
feat: add APort Zapier verification app

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ cd aport-integrations
 
 # Explore integrations by category
 ls examples/
-# agent-frameworks/  ecommerce/  developer-tools/  middleware/  protocol-bridges/
+# agent-frameworks/  ecommerce/  developer-tools/  middleware/  platform-integrations/  protocol-bridges/
 ```
 
 ### 2. Try an Integration
@@ -177,6 +177,7 @@ aport-integrations/
 │   ├── agent-frameworks/        # LangChain, CrewAI, n8n, etc.
 │   ├── ecommerce/              # Shopify, WooCommerce, Stripe
 │   ├── middleware/             # Express, FastAPI, Django, etc.
+│   ├── platform-integrations/  # Zapier and other automation platforms
 │   └── protocol-bridges/       # OpenAPI, AP2, SPIFFE/SPIRE
 ├── tools/                      # Developer tools and utilities
 │   ├── cli/                    # APort CLI for scaffolding
@@ -210,6 +211,13 @@ Make APort the default trust layer for AI agent frameworks.
 | [CrewAI Task Decorator](examples/agent-frameworks/crewai/) | `@aport_verify` decorator for CrewAI tasks | ✅ Active | Community |
 | [n8n APort Node](examples/agent-frameworks/n8n/) | Custom n8n node for APort verification | 🚧 In Progress | Community |
 | [LangGraph Checkpoints](examples/agent-frameworks/langgraph/) | APort verification in LangGraph state machines | 📋 Planned | Community |
+
+### 🔀 **Platform Automation Integrations**
+Make APort verification available in no-code and low-code automation platforms.
+
+| Integration | Description | Status | Maintainer |
+|-------------|-------------|--------|------------|
+| [Zapier Custom App](examples/platform-integrations/zapier/) | APort Verify action for routing Zaps by policy decision | ✅ Active | Community |
 
 ### 🛒 **E-commerce Platform Guardrails**
 Prove the refund use case with working platform integrations.

--- a/examples/platform-integrations/zapier/.env.example
+++ b/examples/platform-integrations/zapier/.env.example
@@ -1,0 +1,2 @@
+APORT_API_KEY=your_api_key_here
+APORT_BASE_URL=https://api.aport.io

--- a/examples/platform-integrations/zapier/README.md
+++ b/examples/platform-integrations/zapier/README.md
@@ -1,0 +1,128 @@
+# APort Zapier App
+
+Zapier Platform CLI app that adds an **APort Verify** action to Zaps. The action accepts a Passport ID, a policy ID, and policy context, calls APort, then returns `allow`, `status`, and decision metadata so a Zap can route with Paths, Filters, or a follow-up action.
+
+## Features
+
+- Custom Zapier app with APort API-key authentication.
+- `APort Verify` action for generic APort policy checks.
+- Routeable output fields: `allow`, `status`, `decision_id`, `reasons`, and raw response data.
+- Optional `Stop Zap on Deny` mode using Zapier's halted task behavior.
+- Unit tests with mocked APort API calls.
+- Example Zap blueprint in `examples/verify-passport-zap.json`.
+
+## Quick Start
+
+```bash
+cd examples/platform-integrations/zapier
+npm install
+npm test
+```
+
+Optional local environment:
+
+```bash
+cp .env.example .env
+```
+
+## Authentication
+
+The app uses Zapier custom authentication fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `APort API Key` | No | Bearer token sent as `Authorization: Bearer <key>` when provided. |
+| `APort API Base URL` | No | Defaults to `https://api.aport.io`; can point to sandbox or self-hosted deployments. |
+
+The authentication test requests `/api/policies` to confirm the configured API endpoint is reachable.
+
+## Action: APort Verify
+
+Input fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `Passport ID` | Yes | APort Passport or agent identifier. |
+| `Policy ID` | Yes | Policy pack identifier such as `finance.payment.refund.v1`. |
+| `Context JSON` | No | JSON object with policy-specific context. Money should use minor units, for example `500` for `$5.00`. |
+| `Idempotency Key` | No | Forwarded in the request body and `Idempotency-Key` header. |
+| `Stop Zap on Deny` | No | If true, denied decisions halt the step. If false, the step returns `allow: false` for routing. |
+
+The request body follows the current APort Node SDK contract:
+
+```json
+{
+  "agent_id": "ap_a2d10232c6534523812423eec8a1425c",
+  "context": {
+    "amount": 500,
+    "currency": "USD",
+    "order_id": "order_123"
+  },
+  "idempotency_key": "zap-run-123"
+}
+```
+
+Example output:
+
+```json
+{
+  "allow": true,
+  "status": "allowed",
+  "agent_id": "ap_a2d10232c6534523812423eec8a1425c",
+  "policy_id": "finance.payment.refund.v1",
+  "decision_id": "dec_123",
+  "assurance_level": "verified",
+  "expires_in": 300,
+  "reasons": []
+}
+```
+
+## Local Zapier Commands
+
+```bash
+# Run unit tests
+npm test
+
+# Validate the app schema
+npm run validate
+
+# Invoke the create action locally after configuring auth/input data
+npx zapier-platform invoke create aport_verify \
+  --inputData '{"agentId":"ap_a2d10232c6534523812423eec8a1425c","policyId":"finance.payment.refund.v1","context":"{\"amount\":500,\"currency\":\"USD\"}"}'
+```
+
+## Publishing as a Private or Public App
+
+1. Install the Zapier Platform CLI and log in:
+   ```bash
+   npm install
+   npx zapier-platform login
+   ```
+2. Register or link the integration:
+   ```bash
+   npx zapier-platform register "APort"
+   ```
+3. Validate and push:
+   ```bash
+   npm run validate
+   npx zapier-platform push
+   ```
+4. In Zapier, create a connection, then add the **APort Verify** action to a Zap.
+
+For public publishing, complete Zapier's review requirements after the private app has been tested with real users and examples.
+
+## Example Zap
+
+See `examples/verify-passport-zap.json` for a refund routing blueprint:
+
+1. Catch a webhook with a Passport ID and refund context.
+2. Run **APort Verify** with `finance.payment.refund.v1`.
+3. Route through Zapier Paths:
+   - `allow = true`: continue the refund workflow.
+   - `allow = false`: notify operations or stop fulfillment.
+
+## Development Notes
+
+- The Zapier action uses native `z.request` so Zapier middleware, auth injection, logging, and testing behavior work normally.
+- `@aporthq/sdk-node` is included as a dependency to match APort's supported JavaScript SDK contract and request shape.
+- No secrets are hardcoded; all credentials come from Zapier authentication fields or local `.env` values during development.

--- a/examples/platform-integrations/zapier/creates/verify_passport.js
+++ b/examples/platform-integrations/zapier/creates/verify_passport.js
@@ -1,0 +1,235 @@
+const DEFAULT_BASE_URL = "https://api.aport.io";
+
+function normalizeBaseUrl(baseUrl) {
+  return (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function parseContext(value, z) {
+  if (value === undefined || value === null || value === "") {
+    return {};
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    throw new z.errors.Error("Context must be a JSON object.");
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new z.errors.Error(`Context must be valid JSON: ${error.message}`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new z.errors.Error("Context must be a JSON object.");
+  }
+
+  return parsed;
+}
+
+function readResponseData(response) {
+  if (response.data !== undefined) {
+    return response.data;
+  }
+
+  const content = response.content || response.body;
+  if (!content) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    return {};
+  }
+}
+
+function normalizeReasons(reasons) {
+  if (!Array.isArray(reasons)) {
+    return [];
+  }
+
+  return reasons.map((reason) => ({
+    code: reason.code || "",
+    message: reason.message || String(reason),
+    severity: reason.severity || "",
+  }));
+}
+
+function extractDecision(payload) {
+  return payload.data?.decision || payload.decision || payload;
+}
+
+function summarizeReasons(reasons) {
+  if (!Array.isArray(reasons) || reasons.length === 0) {
+    return "";
+  }
+
+  return reasons
+    .map((reason) => reason.message || reason.code || String(reason))
+    .join("; ");
+}
+
+function buildErrorMessage(response, payload) {
+  const decision = extractDecision(payload);
+  const details =
+    summarizeReasons(decision.reasons) || summarizeReasons(payload.reasons);
+
+  return (
+    details ||
+    payload.message ||
+    payload.error ||
+    `APort API returned HTTP ${response.status}`
+  );
+}
+
+function isEnabled(value) {
+  return value === true || value === "true" || value === 1 || value === "1";
+}
+
+async function perform(z, bundle) {
+  const agentId = bundle.inputData.agentId;
+  const policyId = bundle.inputData.policyId;
+  const context = parseContext(bundle.inputData.context, z);
+  const idempotencyKey = bundle.inputData.idempotencyKey;
+  const baseUrl = normalizeBaseUrl(bundle.authData.baseUrl);
+
+  const body = {
+    agent_id: agentId,
+    context,
+  };
+
+  if (idempotencyKey) {
+    body.idempotency_key = idempotencyKey;
+  }
+
+  const headers = {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+
+  if (idempotencyKey) {
+    headers["Idempotency-Key"] = idempotencyKey;
+  }
+
+  const response = await z.request({
+    method: "POST",
+    url: `${baseUrl}/api/verify/policy/${encodeURIComponent(policyId)}`,
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const payload = readResponseData(response);
+
+  if (response.status >= 400) {
+    throw new z.errors.Error(buildErrorMessage(response, payload));
+  }
+
+  const decision = extractDecision(payload);
+  const reasons = normalizeReasons(decision.reasons || payload.reasons);
+  const allow = Boolean(
+    decision.allow ?? decision.verified ?? payload.allow ?? payload.verified
+  );
+
+  if (isEnabled(bundle.inputData.failOnDeny) && !allow) {
+    throw new z.errors.HaltedError(
+      summarizeReasons(reasons) || "APort policy verification denied."
+    );
+  }
+
+  return {
+    id: decision.decision_id || `${agentId}:${policyId}`,
+    allow,
+    status: allow ? "allowed" : "denied",
+    agent_id: agentId,
+    policy_id: policyId,
+    decision_id: decision.decision_id || "",
+    assurance_level: decision.assurance_level || "",
+    expires_in: decision.expires_in || null,
+    reasons,
+    raw_response: payload,
+  };
+}
+
+module.exports = {
+  key: "aport_verify",
+  noun: "APort Verification",
+  display: {
+    label: "APort Verify",
+    description:
+      "Verify an APort Passport ID against a policy and return a routeable allow or deny decision.",
+  },
+  operation: {
+    cleanInputData: false,
+    perform,
+    inputFields: [
+      {
+        key: "agentId",
+        label: "Passport ID",
+        type: "string",
+        required: true,
+        helpText: "The APort Passport or agent identifier to verify.",
+      },
+      {
+        key: "policyId",
+        label: "Policy ID",
+        type: "string",
+        required: true,
+        default: "finance.payment.refund.v1",
+        helpText:
+          "Policy pack identifier, for example finance.payment.refund.v1 or code.repository.merge.v1.",
+      },
+      {
+        key: "context",
+        label: "Context JSON",
+        type: "text",
+        required: false,
+        default: "{}",
+        helpText:
+          "JSON object with policy-specific context. Use minor currency units for money, for example 500 for $5.00.",
+      },
+      {
+        key: "idempotencyKey",
+        label: "Idempotency Key",
+        type: "string",
+        required: false,
+        helpText:
+          "Optional unique key forwarded to APort for repeat-safe verification requests.",
+      },
+      {
+        key: "failOnDeny",
+        label: "Stop Zap on Deny",
+        type: "boolean",
+        required: false,
+        default: "false",
+        helpText:
+          "When enabled, a denied decision halts this Zap step. Leave disabled to route using the allow or status output.",
+      },
+    ],
+    outputFields: [
+      { key: "allow", label: "Allowed", type: "boolean" },
+      { key: "status", label: "Status", type: "string" },
+      { key: "agent_id", label: "Passport ID", type: "string" },
+      { key: "policy_id", label: "Policy ID", type: "string" },
+      { key: "decision_id", label: "Decision ID", type: "string" },
+      { key: "assurance_level", label: "Assurance Level", type: "string" },
+      { key: "expires_in", label: "Expires In Seconds", type: "integer" },
+      { key: "reasons", label: "Reasons", list: true },
+    ],
+    sample: {
+      id: "dec_sample_123",
+      allow: true,
+      status: "allowed",
+      agent_id: "ap_sample_agent",
+      policy_id: "finance.payment.refund.v1",
+      decision_id: "dec_sample_123",
+      assurance_level: "verified",
+      expires_in: 300,
+      reasons: [],
+    },
+  },
+};

--- a/examples/platform-integrations/zapier/examples/verify-passport-zap.json
+++ b/examples/platform-integrations/zapier/examples/verify-passport-zap.json
@@ -1,0 +1,44 @@
+{
+  "name": "Route a refund request through APort",
+  "description": "Example Zap blueprint showing how to route automation based on the APort Verify action result.",
+  "steps": [
+    {
+      "type": "trigger",
+      "app": "Webhook by Zapier",
+      "event": "Catch Hook",
+      "output_example": {
+        "passport_id": "ap_a2d10232c6534523812423eec8a1425c",
+        "amount": 500,
+        "currency": "USD",
+        "order_id": "order_123"
+      }
+    },
+    {
+      "type": "action",
+      "app": "APort",
+      "event": "APort Verify",
+      "input": {
+        "agentId": "{{passport_id}}",
+        "policyId": "finance.payment.refund.v1",
+        "context": {
+          "amount": "{{amount}}",
+          "currency": "{{currency}}",
+          "order_id": "{{order_id}}"
+        },
+        "failOnDeny": false
+      }
+    },
+    {
+      "type": "path",
+      "name": "Allowed",
+      "condition": "{{APort Verify.allow}} is true",
+      "next_step": "Continue refund workflow"
+    },
+    {
+      "type": "path",
+      "name": "Denied",
+      "condition": "{{APort Verify.allow}} is false",
+      "next_step": "Notify operations and stop fulfillment"
+    }
+  ]
+}

--- a/examples/platform-integrations/zapier/index.js
+++ b/examples/platform-integrations/zapier/index.js
@@ -1,0 +1,121 @@
+const { version: platformVersion } = require("zapier-platform-core");
+const { version } = require("./package.json");
+const verifyPassport = require("./creates/verify_passport");
+
+const DEFAULT_BASE_URL = "https://api.aport.io";
+
+function normalizeBaseUrl(baseUrl) {
+  return (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+function includeAuthHeaders(request, z, bundle) {
+  const apiKey = bundle.authData.apiKey;
+
+  if (!apiKey) {
+    return request;
+  }
+
+  return {
+    ...request,
+    headers: {
+      ...request.headers,
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+}
+
+function readResponseData(response) {
+  if (response.data !== undefined) {
+    return response.data;
+  }
+
+  const content = response.content || response.body;
+  if (!content) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    return {};
+  }
+}
+
+function summarizeReasons(reasons) {
+  if (!Array.isArray(reasons) || reasons.length === 0) {
+    return "";
+  }
+
+  return reasons
+    .map((reason) => reason.message || reason.code || String(reason))
+    .join("; ");
+}
+
+function throwForAuthErrors(response, z) {
+  if (response.status !== 401 && response.status !== 403) {
+    return response;
+  }
+
+  const data = readResponseData(response);
+  const details = summarizeReasons(data.reasons);
+  const message = details || data.message || "APort authentication failed";
+
+  throw new z.errors.ExpiredAuthError(message);
+}
+
+async function testAuthentication(z, bundle) {
+  const response = await z.request({
+    method: "GET",
+    url: `${normalizeBaseUrl(bundle.authData.baseUrl)}/api/policies`,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  const data = readResponseData(response);
+  const policies = Array.isArray(data) ? data : data.policies || [];
+
+  return {
+    ok: true,
+    policy_count: policies.length,
+    base_url: normalizeBaseUrl(bundle.authData.baseUrl),
+  };
+}
+
+module.exports = {
+  version,
+  platformVersion,
+
+  authentication: {
+    type: "custom",
+    fields: [
+      {
+        key: "apiKey",
+        type: "password",
+        required: false,
+        label: "APort API Key",
+        helpText:
+          "Optional bearer token for APort API calls. Some verification deployments allow public policy checks.",
+      },
+      {
+        key: "baseUrl",
+        type: "string",
+        required: false,
+        label: "APort API Base URL",
+        default: DEFAULT_BASE_URL,
+        helpText:
+          "Override for sandbox or self-hosted APort deployments. Defaults to https://api.aport.io.",
+      },
+    ],
+    test: testAuthentication,
+    connectionLabel: (z, bundle) =>
+      `APort (${normalizeBaseUrl(bundle.authData.baseUrl)})`,
+  },
+
+  beforeRequest: [includeAuthHeaders],
+  afterResponse: [throwForAuthErrors],
+
+  creates: {
+    [verifyPassport.key]: verifyPassport,
+  },
+};

--- a/examples/platform-integrations/zapier/package.json
+++ b/examples/platform-integrations/zapier/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "aport-zapier-app",
+  "version": "1.0.0",
+  "description": "Zapier Platform CLI app for APort policy verification",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "validate": "zapier-platform validate"
+  },
+  "keywords": [
+    "aport",
+    "zapier",
+    "agent-verification",
+    "policy-verification",
+    "automation"
+  ],
+  "author": "APort Community",
+  "license": "MIT",
+  "dependencies": {
+    "@aporthq/sdk-node": "^0.1.3",
+    "zapier-platform-core": "18.6.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "nock": "^13.5.6",
+    "zapier-platform-cli": "18.6.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/examples/platform-integrations/zapier/test/verify_passport.test.js
+++ b/examples/platform-integrations/zapier/test/verify_passport.test.js
@@ -1,0 +1,207 @@
+const zapier = require("zapier-platform-core");
+const nock = require("nock");
+const App = require("../index");
+
+const appTester = zapier.createAppTester(App);
+
+describe("APort Zapier app", () => {
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it("tests authentication by requesting policy metadata", async () => {
+    nock("https://api.aport.io", {
+      reqheaders: {
+        authorization: "Bearer test-key",
+      },
+    })
+      .get("/api/policies")
+      .reply(200, [{ id: "finance.payment.refund.v1" }]);
+
+    const result = await appTester(App.authentication.test, {
+      authData: {
+        apiKey: "test-key",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      policy_count: 1,
+      base_url: "https://api.aport.io",
+    });
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("returns a routeable allow decision for a successful verification", async () => {
+    nock("https://api.aport.io", {
+      reqheaders: {
+        authorization: "Bearer test-key",
+        "idempotency-key": "zap-run-123",
+      },
+    })
+      .post("/api/verify/policy/finance.payment.refund.v1", {
+        agent_id: "ap_test_agent",
+        context: {
+          amount: 500,
+          currency: "USD",
+        },
+        idempotency_key: "zap-run-123",
+      })
+      .reply(200, {
+        allow: true,
+        decision_id: "dec_123",
+        assurance_level: "verified",
+        expires_in: 300,
+        reasons: [],
+      });
+
+    const result = await appTester(App.creates.aport_verify.operation.perform, {
+      authData: {
+        apiKey: "test-key",
+      },
+      inputData: {
+        agentId: "ap_test_agent",
+        policyId: "finance.payment.refund.v1",
+        context: '{"amount":500,"currency":"USD"}',
+        idempotencyKey: "zap-run-123",
+      },
+    });
+
+    expect(result).toMatchObject({
+      id: "dec_123",
+      allow: true,
+      status: "allowed",
+      agent_id: "ap_test_agent",
+      policy_id: "finance.payment.refund.v1",
+      decision_id: "dec_123",
+      assurance_level: "verified",
+      expires_in: 300,
+      reasons: [],
+    });
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("returns a denied decision without throwing by default", async () => {
+    nock("https://api.aport.io")
+      .post("/api/verify/policy/data.export.v1")
+      .reply(200, {
+        allow: false,
+        decision_id: "dec_denied",
+        reasons: [
+          {
+            code: "LIMIT_EXCEEDED",
+            message: "Requested export exceeds the passport row limit.",
+            severity: "error",
+          },
+        ],
+      });
+
+    const result = await appTester(App.creates.aport_verify.operation.perform, {
+      authData: {},
+      inputData: {
+        agentId: "ap_limited_agent",
+        policyId: "data.export.v1",
+        context: {
+          rows: 100000,
+        },
+      },
+    });
+
+    expect(result.allow).toBe(false);
+    expect(result.status).toBe("denied");
+    expect(result.reasons).toEqual([
+      {
+        code: "LIMIT_EXCEEDED",
+        message: "Requested export exceeds the passport row limit.",
+        severity: "error",
+      },
+    ]);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("does not halt when failOnDeny is the Zapier string false value", async () => {
+    nock("https://api.aport.io")
+      .post("/api/verify/policy/data.export.v1")
+      .reply(200, {
+        allow: false,
+        decision_id: "dec_denied_string_flag",
+        reasons: [{ message: "Not allowed for this passport." }],
+      });
+
+    const result = await appTester(App.creates.aport_verify.operation.perform, {
+      authData: {},
+      inputData: {
+        agentId: "ap_limited_agent",
+        policyId: "data.export.v1",
+        context: "{}",
+        failOnDeny: "false",
+      },
+    });
+
+    expect(result.allow).toBe(false);
+    expect(result.status).toBe("denied");
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("halts the Zap when failOnDeny is enabled", async () => {
+    nock("https://api.aport.io")
+      .post("/api/verify/policy/code.repository.merge.v1")
+      .reply(200, {
+        allow: false,
+        reasons: [{ message: "Repository operation is not permitted." }],
+      });
+
+    await expect(
+      appTester(App.creates.aport_verify.operation.perform, {
+        authData: {},
+        inputData: {
+          agentId: "ap_repo_agent",
+          policyId: "code.repository.merge.v1",
+          context: "{}",
+          failOnDeny: true,
+        },
+      })
+    ).rejects.toThrow("Repository operation is not permitted.");
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it("rejects invalid context JSON before calling APort", async () => {
+    await expect(
+      appTester(App.creates.aport_verify.operation.perform, {
+        authData: {},
+        inputData: {
+          agentId: "ap_test_agent",
+          policyId: "finance.payment.refund.v1",
+          context: "{not-json}",
+        },
+      })
+    ).rejects.toThrow("Context must be valid JSON");
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
+  it("surfaces APort API errors with reason details", async () => {
+    nock("https://api.aport.io")
+      .post("/api/verify/policy/finance.payment.refund.v1")
+      .reply(400, {
+        reasons: [
+          {
+            code: "INVALID_CONTEXT",
+            message: "amount is required",
+          },
+        ],
+      });
+
+    await expect(
+      appTester(App.creates.aport_verify.operation.perform, {
+        authData: {},
+        inputData: {
+          agentId: "ap_test_agent",
+          policyId: "finance.payment.refund.v1",
+          context: "{}",
+        },
+      })
+    ).rejects.toThrow("amount is required");
+    expect(nock.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Zapier CLI custom app under examples/platform-integrations/zapier with an APort Verify action.
- Supports custom auth with optional bearer token/base URL, request hooks, and denial handling.
- Documents setup, publish flow, action inputs/outputs, and includes an example refund-verification Zap blueprint.

## Verification
- `npm_config_cache=/private/tmp/codex-npm-cache npm test`
- `XDG_CONFIG_HOME=/private/tmp/codex-config npm_config_cache=/private/tmp/codex-npm-cache npx zapier-platform validate`
- `git diff --check`

Closes #6

Bounty: $50 USD
Preferred payout: BTC 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ