### PR TITLE
feat: add Hello, APort! Go example (#27)

### DIFF
--- a/examples/hello-world/go/README.md
+++ b/examples/hello-world/go/README.md
@@ -1,0 +1,55 @@
+# Hello, APort! (Go Example)
+
+A minimal Go script demonstrating how to call the APort `/verify` endpoint.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) 1.21 or later
+- An APort API key
+
+## Setup
+
+1. **Get an APort API key** by signing up at [aport.io](https://aport.io)
+
+2. **Set your API key as an environment variable:**
+
+```bash
+export APORT_API_KEY=your_api_key_here
+```
+
+3. **(Optional) Set a custom API URL:**
+
+```bash
+export APORT_API_URL=https://api.aport.io/v1/verify
+```
+
+## Running
+
+```bash
+go run main.go
+```
+
+## Expected Output
+
+On success, you will see output similar to:
+
+```
+=== APort Verification Result ===
+Allowed: true
+```
+
+If the action is denied, reasons will be listed:
+
+```
+=== APort Verification Result ===
+Allowed: false
+Reasons denied:
+  - Action "code.deploy" is not authorized for this agent
+```
+
+## How It Works
+
+1. The script reads your API key from the `APORT_API_KEY` environment variable
+2. Constructs a verification request with a sample passport ID, agent ID, action, and resource
+3. Sends a POST request to the APort `/verify` endpoint
+4. Parses the JSON response and displays whether the action is allowed

--- a/examples/hello-world/go/main.go
+++ b/examples/hello-world/go/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// APortVerifyRequest represents the request payload for APort verification.
+type APortVerifyRequest struct {
+	PassportID string `json:"passport_id"`
+	AgentID    string `json:"agent_id"`
+	Action     string `json:"action"`
+	Resource   string `json:"resource"`
+}
+
+// APortVerifyResponse represents the response from APort's verify endpoint.
+type APortVerifyResponse struct {
+	Allow   bool     `json:"allow"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+func main() {
+	// Get APort API key from environment variable
+	apiKey := os.Getenv("APORT_API_KEY")
+	if apiKey == "" {
+		fmt.Println("Error: APORT_API_KEY environment variable is not set")
+		fmt.Println("Set it with: export APORT_API_KEY=your_api_key_here")
+		os.Exit(1)
+	}
+
+	// APort API endpoint (set via environment or use default)
+	apiURL := os.Getenv("APORT_API_URL")
+	if apiURL == "" {
+		apiURL = "https://api.aport.io/v1/verify"
+	}
+
+	// Build the verification request
+	reqBody := APortVerifyRequest{
+		PassportID: "passport_abc123",
+		AgentID:    "agent_demo_001",
+		Action:     "code.deploy",
+		Resource:   "github.com/my-org/my-repo",
+	}
+
+	// Serialize request to JSON
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		fmt.Printf("Error marshaling request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		fmt.Printf("Error creating request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	// Execute the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Error making request: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("Error reading response: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse response
+	var verifyResp APortVerifyResponse
+	if err := json.Unmarshal(body, &verifyResp); err != nil {
+		fmt.Printf("Error parsing response: %v\n", err)
+		fmt.Printf("Raw response: %s\n", string(body))
+		os.Exit(1)
+	}
+
+	// Print results
+	fmt.Println("=== APort Verification Result ===")
+	fmt.Printf("Allowed: %v\n", verifyResp.Allow)
+	if !verifyResp.Allow && len(verifyResp.Reasons) > 0 {
+		fmt.Println("Reasons denied:")
+		for _, reason := range verifyResp.Reasons {
+			fmt.Printf("  - %s\n", reason)
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a minimal, single-file Go example demonstrating how to call the APort `/verify` endpoint.

## Changes

- `examples/hello-world/go/main.go`: Single-file Go script using only `net/http` from the standard library
- `examples/hello-world/go/README.md`: Documentation with setup and run instructions

## Testing

1. Set `APORT_API_KEY` environment variable
2. Run `go run main.go`

## Related

Closes #27
